### PR TITLE
story: fix link for author

### DIFF
--- a/include/story.php
+++ b/include/story.php
@@ -69,7 +69,7 @@ function print_article($a)
 	if ($zid == "") {
 		$by = "<b>Anonymous Coward</b>";
 	} else {
-		$by = "<a href=\"http://$zid\"><b>$zid</b></a>";
+		$by = "<a href=\"" . user_page_link($zid) . "\"><b>$zid</b></a>";
 	}
 	if (array_key_exists("sid", $a)) {
 		$sid = $a["sid"];


### PR DESCRIPTION
the link for each story was pointing at http[s]://author@pipedot.org , thus trying to connect as user "author" to the server "pipedot.org"

After modification it will be pointing at http[s]://author.pipedot.org (i.e. the homepage for author)
